### PR TITLE
Fix: auto create assets parent dir

### DIFF
--- a/impl/client.py
+++ b/impl/client.py
@@ -84,6 +84,7 @@ class _AssetsService(Generic[T]):
         response = await self._remote_get(url, retry)
         if not response:
             return None
+        path.parent.mkdir(parents=True, exist_ok=True)
         async with async_open(path, "wb") as file:
             await file.write(response.content)  # 保存图标
         return path.resolve()


### PR DESCRIPTION
```
│ /app/core/dependence/assets/impl/client.py:87 in _download                                  │
│                                                                                             │
│    84 │   │   response = await self._remote_get(url, retry)                                 │
│    85 │   │   if not response:                                                              │
│    86 │   │   │   return None                                                               │
│ ❱  87 │   │   async with async_open(path, "wb") as file:                                    │
│    88 │   │   │   await file.write(response.content)  # 保存图标                            │
│    89 │   │   return path.resolve()                                                         │
│    90                                                                                       │
│                                                                                             │
│ ╭──────────────────────────────────────── locals ─────────────────────────────────────────╮ │
│ │     self = <core.dependence.assets.impl.genshin._AvatarAssets object at 0x7fe1e5525e20> │ │
│ │      url = 'https://nb-1s.enzonix.com/bucket-1565-2162/data/raw/genshin/character/ambr… │ │
│ │     path = PosixPath('/app/resources/assets/genshin/character/ambr/UI_AvatarIcon_Ayaka… │ │
│ │    retry = 5                                                                            │ │
│ │ response = <Response [200 OK]>                                                          │ │
│ ╰─────────────────────────────────────────────────────────────────────────────────────────╯ │


FileNotFoundError: [Errno 2] No such file or directory:
'/app/resources/assets/genshin/character/ambr/UI_AvatarIcon_Ayaka.png'
```